### PR TITLE
fix(accountNickname):  Set a default accountNickname tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-securityhub": "^3.188.0",
+        "@aws-sdk/client-sts": "^3.188.0",
         "octokit": "^2.0.9"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-securityhub": "^3.188.0",
+    "@aws-sdk/client-sts": "^3.188.0",
     "octokit": "^2.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose

This changeset helps with some backwards compatibility; if no accountNickname is passed, the accountId will be used.

#### Linked Issues to Close

Bug against #101 

## Approach

If no accountNickname is passed, the STS GetCallerIdentity is called to retrieve the account id.  

I don't know of a good pattern to set a default in the constructor that requires an async call, so I do the setting in the sync function.

## Learning

N/A

## Assorted Notes/Considerations

fix()

#### Pull Request Creator Checklist

- [x] Any associated issue(s) are linked above.
- [x] This PR and linked issues(s) are a complete description of the changeset.
- [x] Someone has been assigned this PR.
- [x] Someone has been marked as reviewer on this PR.

#### Pull Request Assignee Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for any linked issues.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
