### PR TITLE
Only sync findings from "Security Hub" product

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,8 +68,8 @@ export class SechubGithubSync {
               ProductName: [
                 {
                   Comparison: "EQUALS",
-                  Value: "Security Hub"
-                }
+                  Value: "Security Hub",
+                },
               ],
               SeverityLabel: severityLabels,
             },


### PR DESCRIPTION
## Purpose

This changeset makes the package only care about Security Hub findings.

#### Linked Issues to Close

None

## Approach

Security Hub displays findings for many different products.  Some of those products aren't appropriate for issue creation.  This is entirely opinion.

This package is taking the stance of only including Security Hub product findings.  All other products, such as Health, will be ignored.

## Learning

None

