### PR TITLE
Use node 18 in GHA to accommodate semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - name: Configure direnv
         uses: HatsuneMiku3939/direnv-action@v1
       - name: Configure AWS credentials


### PR DESCRIPTION
## Purpose

Update workflows to install node 18, to accommodate the latest semantic release we're using.

#### Linked Issues to Close

None

## Approach

Bump the versions in Release and Test workflow files.

## Learning

None

## Assorted Notes/Considerations

None
